### PR TITLE
Guard creationflags for cross-platform subprocess calls

### DIFF
--- a/utils/plugins.py
+++ b/utils/plugins.py
@@ -7,13 +7,21 @@ class Plugins:
         self.exe = os.path.join(self.cwd, *plugin)
 
     def run(self, *args):
-        stdout = subprocess.run(
-            [self.exe, *args],
-            creationflags=subprocess.CREATE_NO_WINDOW,
-            check=False,
-            capture_output=True,
-            text=True,
-        ).stdout
+        # Determine subprocess arguments based on the operating system.
+        # ``creationflags=subprocess.CREATE_NO_WINDOW`` is only available on
+        # Windows. On other platforms, attempting to use it raises an
+        # ``AttributeError``. Detect ``os.name`` and only supply the flag on
+        # Windows to ensure cross-platform compatibility.
+        kwargs = {
+            "check": False,
+            "capture_output": True,
+            "text": True,
+        }
+
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
+        stdout = subprocess.run([self.exe, *args], **kwargs).stdout
         return stdout
 
 


### PR DESCRIPTION
## Summary
- Detect `os.name` before spawning plugin processes
- Only pass `creationflags=subprocess.CREATE_NO_WINDOW` on Windows to avoid AttributeError elsewhere

## Testing
- `python -m py_compile utils/plugins.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7e95cb10832e92d2ce44c6dc30d8