### PR TITLE
Handle missing resfileindex

### DIFF
--- a/cyno_exporter.py
+++ b/cyno_exporter.py
@@ -171,6 +171,10 @@ class ResFileIndex:
                     None,
                 )
 
+                if resfileindex is None:
+                    self.event_logger.add("resfileindex.txt not found in resindex")
+                    return None
+
                 resfileindex_file = f"{build}_resfileindex.txt"
 
                 os.makedirs("resindex", exist_ok=True)


### PR DESCRIPTION
## Summary
- prevent crashes when resfileindex.txt entry is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be81362300832e88a57411ddbc5aa7